### PR TITLE
Ensure daemon reload

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
   systemd:
     name: "{{ item.key }}.service"
     enabled: "{{ item.value.enabled | default(False) }}"
+    daemon_reload: yes
   with_dict: "{{ systemd_service }}"
   tags:
     - systemd-service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   notify:
     - restart service
   tags:
-    - systemd-service
+    - "role::systemd-service"
 
 - name: "create systemd target"
   template:
@@ -17,7 +17,8 @@
     mode: 0664
   with_dict: "{{ systemd_target }}"
   tags:
-    - systemd-service
+    - "role::systemd-service"
+    - "role::systemd-service:configure"
 
 - name: "enable service"
   systemd:
@@ -26,4 +27,5 @@
     daemon_reload: yes
   with_dict: "{{ systemd_service }}"
   tags:
-    - systemd-service
+    - "role::systemd-service"
+    - "role::systemd-service:configure"


### PR DESCRIPTION
In some scenarios, we have seen that role doesnt reload systemd daemon and then the new configuration doesnt apply. So with this, we ensure, it is going to happen again.